### PR TITLE
Fix name typo in manifest.json

### DIFF
--- a/custom_components/tgtg/manifest.json
+++ b/custom_components/tgtg/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "tgtg",
-  "name": "TooGooToGo",
+  "name": "TooGoodToGo",
   "codeowners": ["@chouffy", "@tjorim"],
   "documentation": "https://github.com/Chouffy/home_assistant_tgtg",
   "iot_class": "cloud_polling",


### PR DESCRIPTION
Not a major issue really since the integration cannot be configured through the HA frontend. But a fix nonetheless!

Fixes the following:
![image](https://user-images.githubusercontent.com/561213/219975632-2f0a744f-a6fe-4b97-a854-9c396ae527d9.png)
