### PR TITLE
Revert "Change default locale to en-GB"

### DIFF
--- a/custom_components/tgtg/sensor.py
+++ b/custom_components/tgtg/sensor.py
@@ -74,7 +74,6 @@ def setup_platform(
         user_id=user_id,
         cookie=cookie,
         user_agent=user_agent,
-        language="en-GB",
     )
 
     # If item: isn't defined, use favorites - otherwise use defined items

--- a/tgtg_get_tokens.py
+++ b/tgtg_get_tokens.py
@@ -9,7 +9,7 @@ from tgtg import TgtgClient
 email = input("Type your email linked to your TGTG account: ")
 
 # Set up a tgtg client
-tgtgClient = TgtgClient(email=email,language="en-GB")
+tgtgClient = TgtgClient(email=email)
 tgtgClient.get_credentials()
 
 # You should receive an email from TGTG: click the link inside to continue.


### PR DESCRIPTION
en-GB is the default now in https://github.com/ahivert/tgtg-python/pull/269, no need to keep this.
Reverts Chouffy/home_assistant_tgtg#84