### PR TITLE
Update dockerfile to use python 3.13 base image and include a pip upgrade step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.9-slim
+FROM python:3.13-slim
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
 
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
+
+# Update pip
+RUN python -m pip install --upgrade pip
 
 # Install pip requirements
 COPY requirements.txt .


### PR DESCRIPTION
This change will fix the build of the docker container for the token retrieval step. 