### PR TITLE
Update docker base image to python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.9-slim
+FROM python:3.13-slim
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
 
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
+
+# Update pip
+RUN python -m pip install --upgrade pip
 
 # Install pip requirements
 COPY requirements.txt .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.13-slim
+FROM python:3.9-slim
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
This PR will update the python base image to v3.9 and include a step to update pip. Using the existing dockerfile it was unable to find the 0,18.1 version of the tgtg package.