### PR TITLE
Update sensor.py to avoid too many requests failure

### DIFF
--- a/custom_components/tgtg/sensor.py
+++ b/custom_components/tgtg/sensor.py
@@ -214,7 +214,7 @@ class TGTGSensor(SensorEntity):
         """
         global tgtg_client
         self.tgtg_answer = tgtg_client.get_item(item_id=self.item_id)
-        time.sleep(2)
+        time.sleep(1)
         self.tgtg_orders = tgtg_client.get_active()["orders"]
 
         self.store_name = self.tgtg_answer["display_name"]


### PR DESCRIPTION
Add sleep interval to avoid too many request failures

I was having issues with too many requests failures. After updating one item it would stop updating the rest of the items. So I made this PR which solved the issues I was having.

This was the error I got prior to this fix:

```
Error while setting up tgtg platform for sensor: (429, b'{"errors":[{"code":"TOO_MANY_REQUESTS"}]}')
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 451, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/usr/local/lib/python3.13/concurrent/futures/thread.py", line 59, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/tgtg/sensor.py", line 83, in setup_platform
    add_entities([TGTGSensor(item["item"]["item_id"])])
                  ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/tgtg/sensor.py", line 100, in __init__
    self.update()
    ~~~~~~~~~~~^^
  File "/config/custom_components/tgtg/sensor.py", line 215, in update
    self.tgtg_answer = tgtg_client.get_item(item_id=self.item_id)
                       ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/tgtg/__init__.py", line 280, in get_item
    raise TgtgAPIError(response.status_code, response.content)
tgtg.exceptions.TgtgAPIError: (429, b'{"errors":[{"code":"TOO_MANY_REQUESTS"}]}')
```